### PR TITLE
Add a useful divcenter tip command

### DIFF
--- a/Tips/DivConsoleCommand.cs
+++ b/Tips/DivConsoleCommand.cs
@@ -1,0 +1,44 @@
+using Content.Shared.Ghost;
+using Robust.Client.GameObjects;
+using Robust.Shared.Console;
+using Robust.Shared.Utility;
+
+namespace Content.Client.Tips;
+
+public sealed class DivCenterTip : IConsoleCommand
+{
+    private static readonly string DivHelpText = "Dear Sir/Madam,\n\nI hope this message finds you well.\n\nIn order to center a <div> on a webpage, the most effective method is to use a technique that ensures both horizontal and vertical alignment. One such approach is to configure the container element to take up the full height of the viewport, allowing its child content to be centrally positioned.\n\nThis alignment can be achieved by utilizing modern layout tools, such as Flexbox or Grid, which facilitate the precise centering of elements. These tools work by defining the container as a flex or grid context, with the content aligned both horizontally and vertically.\n\nI trust this explanation proves helpful.\n\nYours sincerely,\n{0}";
+    public string Command => "divcenter";
+    public string Description => "Gets the latest information from ChatGPT on how to center a div";
+    public string Help => "divcenter";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var name = "Mr. ChargleGPT";
+        var hasPlayer = shell.Player != null;
+
+        // If in game make sure everyone knows how to center a div
+        // we need to sign off as the player character JUST to make sure
+        if (hasPlayer)
+        {
+            var entManager = IoCManager.Resolve<IEntityManager>();
+            var meta = entManager.GetComponentOrNull<MetaDataComponent>(shell.Player!.AttachedEntity);
+            if (meta == null)
+            {
+                return;
+            }
+
+            name = meta.EntityName;
+        }
+
+        var formattedDivText = string.Format(DivHelpText, name);
+
+        shell.WriteLine(formattedDivText);
+
+
+        if (hasPlayer)
+        {
+            shell.ExecuteCommand($"looc \"{CommandParsing.Escape(formattedDivText)}\"");
+        }
+    }
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This adds a very useful command (divcenter) which will tell the current player, and everyone in OOC how to center a div

## Why / Balance
99% of people don't know how to center a div, this will be very informative and let people know

## Technical details
Very technical, I can't tell you how I did it

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/ad81b93c-260a-489c-b130-432ac92e88e2)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added a new console command, divcenter, which will inform people and yourself on how to center a div
